### PR TITLE
bible-scraper 2.1.0

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+github: ionicabizau
+patreon: ionicabizau
+open_collective: ionicabizau
+custom: https://www.buymeacoffee.com/h96wwchmy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,66 +1,41 @@
-# :eight_spoked_asterisk: :stars: :sparkles: :dizzy: :star2: :star2: :sparkles: :dizzy: :star2: :star2: Contributing :star: :star2: :dizzy: :sparkles:  :star: :star2: :dizzy: :sparkles: :stars: :eight_spoked_asterisk:
+# Contributing :star: :star2: :dizzy:
 
-So, you want to contribute to this project! That's awesome. However, before
-doing so, please read the following simple steps how to contribute. This will
-make the life easier and will avoid wasting time on things which are not
-requested. :sparkles:
+So, you want to contribute to this project? That's awesome! However, before doing so, please read the following simple steps on how to contribute. This will make life easier and avoid wasting time on things that are not requested. ✨
 
-## Discuss the changes before doing them
- - First of all, open an issue in the repository, using the [bug tracker][1],
-   describing the contribution you would like to make, the bug you found or any
-   other ideas you have. This will help us to get you started on the right
-   foot.
+## Discuss the changes before making them
+To begin, open an issue in the repository using the [bug tracker][1]. Describe the contribution you'd like to make, the bug you've found, or any other ideas you have. This step will help us get you started on the right track.
 
- - If it makes sense, add the platform and software information (e.g. operating
-   system, Node.JS version etc.), screenshots (so we can see what you are
-   seeing).
+If it is relevant, include platform and software information (e.g., operating system, Node.JS version, etc.) and screenshots to help us understand what you're experiencing.
 
- - It is recommended to wait for feedback before continuing to next steps.
-   However, if the issue is clear (e.g. a typo) and the fix is simple, you can
-   continue and fix it.
+We recommend waiting for feedback before proceeding to the next steps. However, if the issue is clear, such as a typo, and the fix is simple, you can go ahead and fix it.
 
-## Fixing issues
- - Fork the project in your account and create a branch with your fix:
-   `some-great-feature` or `some-issue-fix`.
+## Fixing Issues
+Begin by forking the project to your own account, and create a branch for your fix, naming it either `some-great-feature` or `some-issue-fix`.
 
- - Commit your changes in that branch, writing the code following the
-   [code style][2]. If the project contains tests (generally, the `test`
-   directory), you are encouraged to add a test as well. :memo:
+Commit your changes to that branch, adhering to the [code style][2]. If the project includes tests (usually located in the `test` directory), we encourage you to add a test as well. :memo:
 
- - If the project contains a `package.json` or a `bower.json` file add yourself
-   in the `contributors` array (or `authors` in the case of `bower.json`;
-   if the array does not exist, create it):
+If the project includes a `package.json` or a `bower.json` file, add yourself to the `contributors` array (or `authors` in the case of `bower.json`). If the array doesn't exist, create it as shown below:
 
-   ```json
-   {
-      "contributors": [
-         "Your Name <and@email.address> (http://your.website)"
-      ]
-   }
-   ```
+```json
+{
+   "contributors": [
+      "Your Name <your@email.address> (http://your.website)"
+   ]
+}
+```
 
-## Creating a pull request
+## Creating a Pull Request
+Start by opening a pull request and make sure to reference the initial issue in the pull request message (e.g., *fixes #<your-issue-number>*). Provide a clear and descriptive title to help everyone understand what is being fixed or improved.
 
- - Open a pull request, and reference the initial issue in the pull request
-   message (e.g. *fixes #<your-issue-number>*). Write a good description and
-   title, so everybody will know what is fixed/improved.
+If applicable, consider adding screenshots, gifs, or any other visual aids that can make it easier to understand the changes you've made.
 
- - If it makes sense, add screenshots, gifs etc., so it is easier to see what
-   is going on.
+## Wait for Feedback
+Before accepting your contributions, we will review them. You may receive feedback regarding what needs to be addressed in your modified code. If so, simply continue making commits to your branch, and the pull request will be automatically updated.
 
-## Wait for feedback
-Before accepting your contributions, we will review them. You may get feedback
-about what should be fixed in your modified code. If so, just keep committing
-in your branch and the pull request will be updated automatically.
-
-## Everyone is happy!
-Finally, your contributions will be merged, and everyone will be happy! :smile:
-Contributions are more than welcome!
+## Everyone Is Happy!
+Ultimately, your contributions will be merged, and everyone will be delighted! 😄 Contributions are more than welcome!
 
 Thanks! :sweat_smile:
 
-
-
-[1]: https://github.com/IonicaBizau/bible-scraper/issues
-
+[1]: /issues
 [2]: https://github.com/IonicaBizau/code-style

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2,13 +2,29 @@
 
 You can see below the API reference of this module.
 
-### `bibleScraper(translationId)`
-BibleScraper
-Retrieve verses from bible.com/YouVersion. Initializes the `BibleScraper` instance.
+### BibleScraper
+
+Retrieves verses from bible.com, provided by YouVersion. Initializes the `BibleScraper` instance.
 
 #### Params
 
-- **Number** `translationId`: The translation id from bible.com.
+- **Number** `translationId`: - The translation id from bible.com.
+
+### BibleScraper.BOOKS
+
+The available books from bible.com.
+
+### BibleScraper.TRANSLATIONS
+
+The translation ID's from bible.com.
+
+### constructor
+
+Constructor for the class.
+
+#### Params
+
+- **type** `translationId`: - the ID of the Bible translation.
 
 ### `url(reference)`
 Returns the Bible url reference from bible.com.
@@ -19,6 +35,20 @@ Returns the Bible url reference from bible.com.
 
 #### Return
 - **String** The reference url.
+
+### `getBibleReference(params, params.book, params.chapter, [params.verseNumStart], [params.verseNumEnd])`
+Generates a bible reference based on the provided book, chapter, and verse range.
+
+#### Params
+
+- **Object** `params`: - The parameters object.
+- **string** `params.book`: - The name of the book.
+- **number** `params.chapter`: - The chapter number.
+- **number** `[params.verseNumStart]`: - The starting verse number (optional).
+- **number** `[params.verseNumEnd]`: - The ending verse number (optional).
+
+#### Return
+- **string** The generated bible reference.
 
 verse
 Fetches the verse.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021-23 Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)
+Copyright (c) 2021-24 Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -136,13 +136,29 @@ There are few ways to get help:
 ## :memo: Documentation
 
 
-### `bibleScraper(translationId)`
-BibleScraper
-Retrieve verses from bible.com/YouVersion. Initializes the `BibleScraper` instance.
+### BibleScraper
+
+Retrieves verses from bible.com, provided by YouVersion. Initializes the `BibleScraper` instance.
 
 #### Params
 
-- **Number** `translationId`: The translation id from bible.com.
+- **Number** `translationId`: - The translation id from bible.com.
+
+### BibleScraper.BOOKS
+
+The available books from bible.com.
+
+### BibleScraper.TRANSLATIONS
+
+The translation ID's from bible.com.
+
+### constructor
+
+Constructor for the class.
+
+#### Params
+
+- **type** `translationId`: - the ID of the Bible translation.
 
 ### `url(reference)`
 Returns the Bible url reference from bible.com.
@@ -153,6 +169,20 @@ Returns the Bible url reference from bible.com.
 
 #### Return
 - **String** The reference url.
+
+### `getBibleReference(params, params.book, params.chapter, [params.verseNumStart], [params.verseNumEnd])`
+Generates a bible reference based on the provided book, chapter, and verse range.
+
+#### Params
+
+- **Object** `params`: - The parameters object.
+- **string** `params.book`: - The name of the book.
+- **number** `params.chapter`: - The chapter number.
+- **number** `[params.verseNumStart]`: - The starting verse number (optional).
+- **number** `[params.verseNumEnd]`: - The ending verse number (optional).
+
+#### Return
+- **string** The generated bible reference.
 
 verse
 Fetches the verse.
@@ -221,6 +251,13 @@ Thanks! :heart:
 
 
 
+
+
+
+## :dizzy: Where is this library used?
+If you are using this library in one of your projects, add it in this list. :sparkles:
+
+ - `@everything-registry/sub-chunk-1232`
 
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -157,17 +157,62 @@ const booksAndUsfmShortcodes = {
     'Revelation': 'REV'
 }
 
+/**
+ * BibleScraper
+ * 
+ * Retrieves verses from bible.com, provided by YouVersion. Initializes the `BibleScraper` instance.
+ * 
+ * @class
+ * @name BibleScraper
+ * 
+ * @param {Number} translationId - The translation id from bible.com.
+ * 
+ * @example
+ * const NLTBibleScraper = new BibleScraper(BibleScraper.TRANSLATIONS.NLT);
+ * const reference = NLTBibleScraper.getBibleReference({ 
+ *   book: BibleScraper.BOOKS.GENESIS,
+ *   chapter: 1,
+ *   verseNumStart: 1,
+ *   verseNumEnd: 3 
+ * });
+ * console.log(reference);
+ * // Output: "GEN.1.1-3.116"
+ * 
+ * const verseData = await NLTBibleScraper.verse(reference);
+ * console.log(verseData);
+ * // Output: { content: "In the beginning God created the heavens and the earth.", reference: "Genesis 1:1" }
+ * 
+ * const chapterData = await NLTBibleScraper.chapter('GEN.1');
+ * console.log(chapterData);
+ * // Output: { verses: [ { content: "In the beginning God created the heavens and the earth.", reference: "Genesis 1:1" }, ... ] }
+ */
 module.exports = class BibleScraper {
+    /**
+     * The available books from bible.com.
+     * 
+     * @name BibleScraper.BOOKS
+     * @type {BOOKS<booksAndUsfmShortcodes>}
+     * @readonly
+     * 
+     */
     static BOOKS = Object.keys(booksAndUsfmShortcodes);
+
+    /**
+     * The translation ID's from bible.com.
+     * 
+     * @name BibleScraper.TRANSLATIONS
+     * @type {TRANSLATIONS}
+     * @readonly
+     * 
+     */
     static TRANSLATIONS = TRANSLATIONS;
 
     /**
-     * BibleScraper
-     * Retrieve verses from bible.com/YouVersion. Initializes the `BibleScraper` instance.
+     * Constructor for the class.
      *
-     * @name bibleScraper
-     * @function
-     * @param {Number} translationId The translation id from bible.com.
+     * @param {type} translationId - the ID of the Bible translation.
+     * 
+     * @throws {Error} - if translationId is not provided.
      */
     constructor(translationId) {
         if (!translationId) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ module.exports = class BibleScraper {
      * @function
      * @param {Number} translationId The translation id from bible.com.
      */
-    constructor (translationId) {
+    constructor(translationId) {
         this.translation_id = translationId
     }
 
@@ -23,7 +23,7 @@ module.exports = class BibleScraper {
      * @param {String} reference The Bible reference to get the url for.
      * @returns {String} The reference url.
      */
-    url (reference) {
+    url(reference) {
         // TODO Validation
         return `https://www.bible.com/bible/${this.translation_id}/${reference}`
     }
@@ -35,7 +35,7 @@ module.exports = class BibleScraper {
      * @param {String} ref The Bible.com verse reference.
      * @returns {Promise} A promise resolving the verse object.
      */
-    async verse (ref) {
+    async verse(ref) {
         const { data } = await scrapeIt(this.url(ref), {
             content: {
                 selector: "p.text-19",
@@ -56,19 +56,19 @@ module.exports = class BibleScraper {
      * @param {String} ref The Bible.com chapter reference.
      * @returns {Promise} A promise resolving the chapter object.
      */
-    async chapter (ref) {
+    async chapter(ref) {
         const { data } = await scrapeIt(this.url(ref), {
             verses: {
                 listItem: "span.ChapterContent_verse__57FIw[data-usfm]",
-                    data: {
-                        content: {
-                            selector: "span.ChapterContent_content__RrUqA",
-                            how: "text"
-                        },
-                        reference: {
-                            attr: "data-usfm"
-                        }
+                data: {
+                    content: {
+                        selector: "span.ChapterContent_content__RrUqA",
+                        how: "text"
+                    },
+                    reference: {
+                        attr: "data-usfm"
                     }
+                }
             }
         })
 
@@ -85,10 +85,84 @@ module.exports = class BibleScraper {
     }
 }
 
+// Bible version ID's were found on https://www.bible.com/versions.
+const ENGLISH_BIBLE_VERSION_IDS = {
+    AMP: 1588,
+    AMPC: 8,
+    ASV: 12,
+    BOOKS: 31,
+    BSB: 3034,
+    CEB: 37,
+    CEV: 392,
+    CEVDCI: 303,
+    CEVUK: 294,
+    CJB: 1275,
+    CPDV: 42,
+    CSB: 1713,
+    DARBY: 478,
+    DRC1752: 55,
+    EASY: 2079,
+    ERV: 406,
+    ESV: 59,
+    FBV: 1932,
+    FNVNT: 3633,
+    GNBDC: 416,
+    GNBDK: 431,
+    GNBUK: 296,
+    GNT: 68,
+    GNTD: 69,
+    GNV: 2163,
+    GW: 70,
+    GWC: 1047,
+    HCSB: 72,
+    ICB: 1359,
+    JUB: 1077,
+    KJV: 1,
+    KJVAAE: 546,
+    KJVAE: 547,
+    LEB: 90,
+    LSB: 3345,
+    MEV: 1171,
+    MP1650: 1365,
+    MP1781: 3051,
+    MSG: 97,
+    NABRE: 463,
+    NASB1995: 100,
+    NASB2020: 2692,
+    NCV: 105,
+    NET: 107,
+    NIRV: 110,
+    NIV: 111,
+    NIVUK: 113,
+    NKJV: 114,
+    NLT: 116,
+    NMV: 2135,
+    NRSV: 2015,
+    NRSVUE: 3523,
+    PEV: 2530,
+    RAD: 2753,
+    RSV: 2017,
+    RSVCI: 3548,
+    RV1885: 477,
+    RV1895: 1922,
+    TCENT: 3427,
+    TEG: 3010,
+    TLV: 314,
+    TOJB2011: 130,
+    TPT: 1849,
+    TS2009: 316,
+    WBMS: 2407,
+    WEBBE: 1204,
+    WEBUS: 206,
+    WMB: 1209,
+    WMBBE: 1207,
+    YLT98: 821
+}
+
 // TODO Add the other translation ids
 module.exports.TRANSLATIONS = {
-    KJV: 1
-  , VULG: 823
-  , ICL00D: 1196
-  , NR06: 122
+    VULG: 823,
+    ICL00D: 1196,
+    NR06: 122,
+    ...ENGLISH_BIBLE_VERSION_IDS,
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -276,7 +276,7 @@ module.exports = class BibleScraper {
         const verse = {
             content: '',
             reference: '',
-            version: ''
+            version: '',
         }
 
         // This is a more robust way to get the verse. The old way
@@ -297,11 +297,12 @@ module.exports = class BibleScraper {
             const content = nextJSData.props.pageProps.verses[0].content
             const reference = nextJSData.props.pageProps.verses[0].reference.human
             const version = nextJSData.props.pageProps.version.local_abbreviation
+            
+            verse.version = version
+            verse.content = content
+            verse.reference = reference + ' ' + version
 
-            if (content && reference) {
-                verse.content = content
-                verse.reference = reference + ' ' + version
-                verse.version = version
+            if (verse.content && verse.reference) {
 
                 return verse
             }
@@ -338,6 +339,8 @@ module.exports = class BibleScraper {
             version: '',
             reference: '',
             audioBibleUrl: '',
+            copyright: '',
+            audioBibleCopyright: '',
         }
         
         const { data } = await scrapeIt(this.url(ref), {
@@ -362,11 +365,15 @@ module.exports = class BibleScraper {
         let bibleReferenceWithoutVersion = '';
         if (data.nextJSDataString) {
             const nextJSData = JSON.parse(data.nextJSDataString || '{}')
-
-            chapter.version = nextJSData.props.pageProps.versionData.local_abbreviation
+            
             bibleReferenceWithoutVersion = nextJSData.props.pageProps.chapterInfo.reference.human
-            chapter.reference = nextJSData.props.pageProps.chapterInfo.reference.human + ' ' + chapter.version
-            chapter.audioBibleUrl = nextJSData.props.pageProps.chapterInfo.audioChapterInfo[0].download_urls.format_mp3_32k;
+            let audioBibleUrl = nextJSData.props.pageProps.chapterInfo.audioChapterInfo[0].download_urls.format_mp3_32k
+            
+            chapter.version = nextJSData.props.pageProps.versionData.local_abbreviation
+            chapter.reference = bibleReferenceWithoutVersion + ' ' + chapter.version
+            chapter.audioBibleUrl = audioBibleUrl.replace('//', 'https://')
+            chapter.copyright = nextJSData.props.pageProps.chapterInfo.copyright.text
+            chapter.audioBibleCopyright = nextJSData.props.pageProps.audioVersionInfo.copyright_short.text
         }
 
         chapter.verses = (data.verses || []).reduce((acc, c) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,12 +76,14 @@ const ENGLISH_BIBLE_VERSION_IDS = {
     YLT98: 821
 }
 
-export const TRANSLATIONS = {
+const TRANSLATIONS = {
     VULG: 823,
     ICL00D: 1196,
     NR06: 122,
     ...ENGLISH_BIBLE_VERSION_IDS,
 }
+
+module.exports.TRANSLATIONS = TRANSLATIONS;
 
 // Bible book names each have a short code called a USFM code. 
 // These can be found here: https://ubsicap.github.io/usfm/identification/books.html
@@ -210,7 +212,7 @@ module.exports = class BibleScraper {
         let bibleReference = `${booksAndUsfmShortcodes[book]}.${chapter}`;
 
         if (verseNumStart && verseNumEnd) {
-            bibleReference += `${bibleReference}.${verseNumStart}-${verseNumEnd}.${this.translation_id}`;
+            bibleReference = `${bibleReference}.${verseNumStart}-${verseNumEnd}.${this.translation_id}`;
         } else if (verseNumStart && !verseNumEnd) {
             bibleReference = `${bibleReference}.${verseNumStart}.${this.translation_id}`;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,89 +2,6 @@
 
 const scrapeIt = require("scrape-it")
 
-module.exports = class BibleScraper {
-    /**
-     * BibleScraper
-     * Retrieve verses from bible.com/YouVersion. Initializes the `BibleScraper` instance.
-     *
-     * @name bibleScraper
-     * @function
-     * @param {Number} translationId The translation id from bible.com.
-     */
-    constructor(translationId) {
-        this.translation_id = translationId
-    }
-
-
-    /**
-     * url
-     * Returns the Bible url reference from bible.com.
-     *
-     * @param {String} reference The Bible reference to get the url for.
-     * @returns {String} The reference url.
-     */
-    url(reference) {
-        // TODO Validation
-        return `https://www.bible.com/bible/${this.translation_id}/${reference}`
-    }
-
-    /**
-     * verse
-     * Fetches the verse.
-     *
-     * @param {String} ref The Bible.com verse reference.
-     * @returns {Promise} A promise resolving the verse object.
-     */
-    async verse(ref) {
-        const { data } = await scrapeIt(this.url(ref), {
-            content: {
-                selector: "p.text-19",
-                eq: 0
-            },
-            reference: {
-                selector: "h2.mbe-2",
-                eq: 0
-            }
-        })
-        return data
-    }
-
-    /**
-     * chapter
-     * Fetches the chapter verses.
-     *
-     * @param {String} ref The Bible.com chapter reference.
-     * @returns {Promise} A promise resolving the chapter object.
-     */
-    async chapter(ref) {
-        const { data } = await scrapeIt(this.url(ref), {
-            verses: {
-                listItem: "span.ChapterContent_verse__57FIw[data-usfm]",
-                data: {
-                    content: {
-                        selector: "span.ChapterContent_content__RrUqA",
-                        how: "text"
-                    },
-                    reference: {
-                        attr: "data-usfm"
-                    }
-                }
-            }
-        })
-
-        data.verses = (data.verses || []).reduce((acc, c) => {
-            const latest = acc[acc.length - 1]
-            if (latest && latest.reference === c.reference) {
-                latest.content = (latest.content + " " + c.content).trim()
-            } else {
-                acc.push(c)
-            }
-            return acc
-        }, [])
-        return data
-    }
-}
-
 // Bible version ID's were found on https://www.bible.com/versions.
 const ENGLISH_BIBLE_VERSION_IDS = {
     AMP: 1588,
@@ -166,3 +83,191 @@ module.exports.TRANSLATIONS = {
     NR06: 122,
     ...ENGLISH_BIBLE_VERSION_IDS,
 }
+
+// Bible book names each have a short code called a USFM code. 
+// These can be found here: https://ubsicap.github.io/usfm/identification/books.html
+const booksAndUsfmShortcodes = {
+    'Genesis': 'GEN',
+    'Exodus': 'EXO',
+    'Leviticus': 'LEV',
+    'Numbers': 'NUM',
+    'Deuteronomy': 'DEU',
+    'Joshua': 'JOS',
+    'Judges': 'JDG',
+    'Ruth': 'RUT',
+    '1 Samuel': '1SA',
+    '2 Samuel': '2SA',
+    '1 Kings': '1KI',
+    '2 Kings': '2KI',
+    '1 Chronicles': '1CH',
+    '2 Chronicles': '2CH',
+    'Ezra': 'EZR',
+    'Nehemiah': 'NEH',
+    'Esther': 'EST',
+    'Job': 'JOB',
+    'Psalms': 'PSA',
+    'Psalm': 'PSA',
+    'Proverbs': 'PRO',
+    'Ecclesiastes': 'ECC',
+    'Song of Solomon': 'SNG',
+    'Isaiah': 'ISA',
+    'Jeremiah': 'JER',
+    'Lamentations': 'LAM',
+    'Ezekiel': 'EZK',
+    'Daniel': 'DAN',
+    'Hosea': 'HOS',
+    'Joel': 'JOL',
+    'Amos': 'AMO',
+    'Obadiah': 'OBA',
+    'Jonah': 'JON',
+    'Micah': 'MIC',
+    'Nahum': 'NAM',
+    'Habakkuk': 'HAB',
+    'Zephaniah': 'ZEP',
+    'Haggai': 'HAG',
+    'Zechariah': 'ZEC',
+    'Malachi': 'MAL',
+    'Matthew': 'MAT',
+    'Mark': 'MRK',
+    'Luke': 'LUK',
+    'John': 'JHN',
+    'Acts': 'ACT',
+    'Romans': 'ROM',
+    '1 Corinthians': '1CO',
+    '2 Corinthians': '2CO',
+    'Galatians': 'GAL',
+    'Ephesians': 'EPH',
+    'Philippians': 'PHP',
+    'Colossians': 'COL',
+    '1 Thessalonians': '1TH',
+    '2 Thessalonians': '2TH',
+    '1 Timothy': '1TI',
+    '2 Timothy': '2TI',
+    'Titus': 'TIT',
+    'Philemon': 'PHM',
+    'Hebrews': 'HEB',
+    'James': 'JAS',
+    '1 Peter': '1PE',
+    '2 Peter': '2PE',
+    '1 John': '1JN',
+    '2 John': '2JN',
+    '3 John': '3JN',
+    'Jude': 'JUD',
+    'Revelation': 'REV'
+}
+
+module.exports = class BibleScraper {
+    /**
+     * BibleScraper
+     * Retrieve verses from bible.com/YouVersion. Initializes the `BibleScraper` instance.
+     *
+     * @name bibleScraper
+     * @function
+     * @param {Number} translationId The translation id from bible.com.
+     */
+    constructor(translationId) {
+        this.translation_id = translationId
+        this.bookNames = Object.keys(booksAndUsfmShortcodes)
+    }
+
+    /**
+     * url
+     * Returns the Bible url reference from bible.com.
+     *
+     * @param {String} reference The Bible reference to get the url for.
+     * @returns {String} The reference url.
+     */
+    url(reference) {
+        // TODO Validation
+        return `https://www.bible.com/bible/${this.translation_id}/${reference}`
+    }
+
+    /**
+     * Generates a bible reference based on the provided book, chapter, and verse range.
+     *
+     * @param {Object} params - The parameters object.
+     * @param {string} params.book - The name of the book.
+     * @param {number} params.chapter - The chapter number.
+     * @param {number} [params.verseNumStart] - The starting verse number (optional).
+     * @param {number} [params.verseNumEnd] - The ending verse number (optional).
+     * 
+     * @return {string} The generated bible reference.
+     */
+    getBibleReference({ book, chapter, verseNumStart, verseNumEnd }) {
+        if (!Object.keys(booksAndUsfmShortcodes).includes(book)) {
+            console.warn(`Please provide a valid book name using the \`BibleScraper.bookNames\` object. Available books: ${Object.keys(booksAndUsfmShortcodes).join(', ')}`)
+        }
+
+        if (!chapter) {
+            console.warn('Please provide a chapter number.')
+        }
+
+        let bibleReference = `${booksAndUsfmShortcodes[book]}.${chapter}`;
+
+        if (verseNumStart && verseNumEnd) {
+            bibleReference += `${bibleReference}.${verseNumStart}-${verseNumEnd}.${this.translation_id}`;
+        } else if (verseNumStart && !verseNumEnd) {
+            bibleReference = `${bibleReference}.${verseNumStart}.${this.translation_id}`;
+        }
+
+        return bibleReference
+    }
+
+    /**
+     * verse
+     * Fetches the verse.
+     *
+     * @param {String} ref The Bible.com verse reference.
+     * @returns {Promise} A promise resolving the verse object.
+     */
+    async verse(ref) {
+        const { data } = await scrapeIt(this.url(ref), {
+            content: {
+                selector: "p.text-19",
+                eq: 0
+            },
+            reference: {
+                selector: "h2.mbe-2",
+                eq: 0
+            }
+        })
+        return data
+    }
+
+    /**
+     * chapter
+     * Fetches the chapter verses.
+     *
+     * @param {String} ref The Bible.com chapter reference.
+     * @returns {Promise} A promise resolving the chapter object.
+     */
+    async chapter(ref) {
+        const { data } = await scrapeIt(this.url(ref), {
+            verses: {
+                listItem: "span.ChapterContent_verse__57FIw[data-usfm]",
+                data: {
+                    content: {
+                        selector: "span.ChapterContent_content__RrUqA",
+                        how: "text"
+                    },
+                    reference: {
+                        attr: "data-usfm"
+                    }
+                }
+            }
+        })
+
+        data.verses = (data.verses || []).reduce((acc, c) => {
+            const latest = acc[acc.length - 1]
+            if (latest && latest.reference === c.reference) {
+                latest.content = (latest.content + " " + c.content).trim()
+            } else {
+                acc.push(c)
+            }
+            return acc
+        }, [])
+        return data
+    }
+}
+
+module.exports.BOOK_NAMES = Object.keys(booksAndUsfmShortcodes)

--- a/lib/index.js
+++ b/lib/index.js
@@ -273,6 +273,41 @@ module.exports = class BibleScraper {
      * @returns {Promise} A promise resolving the verse object.
      */
     async verse(ref) {
+        const verse = {
+            content: '',
+            reference: '',
+            version: ''
+        }
+
+        // This is a more robust way to get the verse. The old way
+        // was fragile. If a className changed, then it'd break this
+        // entire package. Bible.com is built using NextJS and on this
+        // page the __NEXT_DATA__ provides us with all the verse data
+        // we need. In the event that this method fails, there is a fallback 
+        // to the old way.
+        const { data: nextJSDataString } = await scrapeIt(this.url(ref), {
+            json: {
+                selector: "script#__NEXT_DATA__",
+                eq: 0
+            },
+        })
+
+        if (nextJSDataString) {
+            const nextJSData = JSON.parse(nextJSDataString.json || '{}')
+            const content = nextJSData.props.pageProps.verses[0].content
+            const reference = nextJSData.props.pageProps.verses[0].reference.human
+            const version = nextJSData.props.pageProps.version.local_abbreviation
+
+            if (content && reference) {
+                verse.content = content
+                verse.reference = reference + ' ' + version
+                verse.version = version
+
+                return verse
+            }
+        }
+
+        // fallback to old way
         const { data } = await scrapeIt(this.url(ref), {
             content: {
                 selector: "p.text-19",
@@ -283,6 +318,7 @@ module.exports = class BibleScraper {
                 eq: 0
             }
         })
+
         return data
     }
 
@@ -294,31 +330,64 @@ module.exports = class BibleScraper {
      * @returns {Promise} A promise resolving the chapter object.
      */
     async chapter(ref) {
+        const chapter = {
+            verses: [{
+                content: '',
+                reference: '',
+            }],
+            version: '',
+            reference: '',
+            audioBibleUrl: '',
+        }
+        
         const { data } = await scrapeIt(this.url(ref), {
             verses: {
-                listItem: "span.ChapterContent_verse__57FIw[data-usfm]",
+                listItem: 'span[data-usfm][class*="ChapterContent_verse_"]',
                 data: {
                     content: {
-                        selector: "span.ChapterContent_content__RrUqA",
+                        selector: 'span[class*="ChapterContent_content_"]',
                         how: "text"
                     },
                     reference: {
                         attr: "data-usfm"
                     }
                 }
-            }
+            },
+            nextJSDataString: {
+                selector: "script#__NEXT_DATA__",
+                eq: 0
+            },
         })
 
-        data.verses = (data.verses || []).reduce((acc, c) => {
+        let bibleReferenceWithoutVersion = '';
+        if (data.nextJSDataString) {
+            const nextJSData = JSON.parse(data.nextJSDataString || '{}')
+
+            chapter.version = nextJSData.props.pageProps.versionData.local_abbreviation
+            bibleReferenceWithoutVersion = nextJSData.props.pageProps.chapterInfo.reference.human
+            chapter.reference = nextJSData.props.pageProps.chapterInfo.reference.human + ' ' + chapter.version
+            chapter.audioBibleUrl = nextJSData.props.pageProps.chapterInfo.audioChapterInfo[0].download_urls.format_mp3_32k;
+        }
+
+        chapter.verses = (data.verses || []).reduce((acc, c) => {
             const latest = acc[acc.length - 1]
+
             if (latest && latest.reference === c.reference) {
                 latest.content = (latest.content + " " + c.content).trim()
             } else {
                 acc.push(c)
             }
+
             return acc
         }, [])
-        return data
+
+        // Adding a readable verse reference to each verse.
+        chapter.verses.forEach((verse) => {
+            const verseNum = verse.reference.split('.')[2]
+            verse.reference = `${bibleReferenceWithoutVersion}:${verseNum}`
+        })
+
+        return chapter
     }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,8 +76,7 @@ const ENGLISH_BIBLE_VERSION_IDS = {
     YLT98: 821
 }
 
-// TODO Add the other translation ids
-module.exports.TRANSLATIONS = {
+export const TRANSLATIONS = {
     VULG: 823,
     ICL00D: 1196,
     NR06: 122,
@@ -157,6 +156,9 @@ const booksAndUsfmShortcodes = {
 }
 
 module.exports = class BibleScraper {
+    static BOOKS = Object.keys(booksAndUsfmShortcodes);
+    static TRANSLATIONS = TRANSLATIONS;
+
     /**
      * BibleScraper
      * Retrieve verses from bible.com/YouVersion. Initializes the `BibleScraper` instance.
@@ -166,8 +168,11 @@ module.exports = class BibleScraper {
      * @param {Number} translationId The translation id from bible.com.
      */
     constructor(translationId) {
+        if (!translationId) {
+            throw new Error('Bible translation ID is required and is available via `BibleScraper.TRANSLATIONS`.')
+        }
+
         this.translation_id = translationId
-        this.bookNames = Object.keys(booksAndUsfmShortcodes)
     }
 
     /**
@@ -194,8 +199,8 @@ module.exports = class BibleScraper {
      * @return {string} The generated bible reference.
      */
     getBibleReference({ book, chapter, verseNumStart, verseNumEnd }) {
-        if (!Object.keys(booksAndUsfmShortcodes).includes(book)) {
-            console.warn(`Please provide a valid book name using the \`BibleScraper.bookNames\` object. Available books: ${Object.keys(booksAndUsfmShortcodes).join(', ')}`)
+        if (!BibleScraper.BOOKS.includes(book)) {
+            console.warn('Please provide a valid book name using the `BibleScraper.BOOKS` array.')
         }
 
         if (!chapter) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "version": "2.0.1",
   "main": "lib/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest tests/index.test.js"
   },
   "author": "Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)",
   "homepage": "https://github.com/IonicaBizau/bible-scraper#readme",
@@ -45,5 +45,8 @@
   },
   "contributors": [
     "Simone Guarnuccio <simoneguarnuccio@gmail.com>"
-  ]
+  ],
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "youversion"
   ],
   "license": "MIT",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -84,6 +84,7 @@ describe('BibleScraper', () => {
       const expectedVerse = {
         content: 'In the beginning God created the heaven and the earth.',
         reference: 'Genesis 1:1 KJV',
+        version: 'KJV',
       };
 
       const verse = await bibleScraper.verse(reference);
@@ -97,137 +98,141 @@ describe('BibleScraper', () => {
       const bibleScraper = new BibleScraper(translationId);
       const reference = 'GEN.1';
       const expectedChapter = {
-        "verses": [
+        reference: "Genesis 1 KJV",
+        version: 'KJV',
+        verses: [
           {
             "content": "In the beginning God created the heaven and the earth.",
-            "reference": "GEN.1.1"
+            "reference": "Genesis 1:1"
           },
           {
             "content": "And the earth was without form, and void; and darkness was upon the face of the deep. And the Spirit of God moved upon the face of the waters.",
-            "reference": "GEN.1.2"
+            "reference": "Genesis 1:2"
           },
           {
             "content": "And God said, Let there be light: and there was light.",
-            "reference": "GEN.1.3"
+            "reference": "Genesis 1:3"
           },
           {
             "content": "And God saw the light, that it was good: and God divided the light from the darkness.",
-            "reference": "GEN.1.4"
+            "reference": "Genesis 1:4"
           },
           {
             "content": "And God called the light Day, and the darkness he called Night. And the evening and the morning were the first day.",
-            "reference": "GEN.1.5"
+            "reference": "Genesis 1:5"
           },
           {
             "content": "And God said, Let there be a firmament in the midst of the waters, and let it divide the waters from the waters.",
-            "reference": "GEN.1.6"
+            "reference": "Genesis 1:6"
           },
           {
             "content": "And God made the firmament, and divided the waters which were under the firmament from the waters which were above the firmament: and it was so.",
-            "reference": "GEN.1.7"
+            "reference": "Genesis 1:7"
           },
           {
             "content": "And God called the firmament Heaven. And the evening and the morning were the second day.",
-            "reference": "GEN.1.8"
+            "reference": "Genesis 1:8"
           },
           {
             "content": "And God said, Let the waters under the heaven be gathered together unto one place, and let the dry land appear: and it was so.",
-            "reference": "GEN.1.9"
+            "reference": "Genesis 1:9"
           },
           {
             "content": "And God called the dry land Earth; and the gathering together of the waters called he Seas: and God saw that it was good.",
-            "reference": "GEN.1.10"
+            "reference": "Genesis 1:10"
           },
           {
             "content": "And God said, Let the earth bring forth grass, the herb yielding seed, and the fruit tree yielding fruit after his kind, whose seed is in itself, upon the earth: and it was so.",
-            "reference": "GEN.1.11"
+            "reference": "Genesis 1:11"
           },
           {
             "content": "And the earth brought forth grass, and herb yielding seed after his kind, and the tree yielding fruit, whose seed was in itself, after his kind: and God saw that it was good.",
-            "reference": "GEN.1.12"
+            "reference": "Genesis 1:12"
           },
           {
             "content": "And the evening and the morning were the third day.",
-            "reference": "GEN.1.13"
+            "reference": "Genesis 1:13"
           },
           {
             "content": "And God said, Let there be lights in the firmament of the heaven to divide the day from the night; and let them be for signs, and for seasons, and for days, and years:",
-            "reference": "GEN.1.14"
+            "reference": "Genesis 1:14"
           },
           {
             "content": "and let them be for lights in the firmament of the heaven to give light upon the earth: and it was so.",
-            "reference": "GEN.1.15"
+            "reference": "Genesis 1:15"
           },
           {
             "content": "And God made two great lights; the greater light to rule the day, and the lesser light to rule the night: he made the stars also.",
-            "reference": "GEN.1.16"
+            "reference": "Genesis 1:16"
           },
           {
             "content": "And God set them in the firmament of the heaven to give light upon the earth,",
-            "reference": "GEN.1.17"
+            "reference": "Genesis 1:17"
           },
           {
             "content": "and to rule over the day and over the night, and to divide the light from the darkness: and God saw that it was good.",
-            "reference": "GEN.1.18"
+            "reference": "Genesis 1:18"
           },
           {
             "content": "And the evening and the morning were the fourth day.",
-            "reference": "GEN.1.19"
+            "reference": "Genesis 1:19"
           },
           {
             "content": "And God said, Let the waters bring forth abundantly the moving creature that hath life, and fowl that may fly above the earth in the open firmament of heaven.",
-            "reference": "GEN.1.20"
+            "reference": "Genesis 1:20"
           },
           {
             "content": "And God created great whales, and every living creature that moveth, which the waters brought forth abundantly, after their kind, and every winged fowl after his kind: and God saw that it was good.",
-            "reference": "GEN.1.21"
+            "reference": "Genesis 1:21"
           },
           {
             "content": "And God blessed them, saying, Be fruitful, and multiply, and fill the waters in the seas, and let fowl multiply in the earth.",
-            "reference": "GEN.1.22"
+            "reference": "Genesis 1:22"
           },
           {
             "content": "And the evening and the morning were the fifth day.",
-            "reference": "GEN.1.23"
+            "reference": "Genesis 1:23"
           },
           {
             "content": "And God said, Let the earth bring forth the living creature after his kind, cattle, and creeping thing, and beast of the earth after his kind: and it was so.",
-            "reference": "GEN.1.24"
+            "reference": "Genesis 1:24"
           },
           {
             "content": "And God made the beast of the earth after his kind, and cattle after their kind, and every thing that creepeth upon the earth after his kind: and God saw that it was good.",
-            "reference": "GEN.1.25"
+            "reference": "Genesis 1:25"
           },
           {
             "content": "And God said, Let us make man in our image, after our likeness: and let them have dominion over the fish of the sea, and over the fowl of the air, and over the cattle, and over all the earth, and over every creeping thing that creepeth upon the earth.",
-            "reference": "GEN.1.26"
+            "reference": "Genesis 1:26"
           },
           {
             "content": "So God created man in his own image, in the image of God created he him; male and female created he them.",
-            "reference": "GEN.1.27"
+            "reference": "Genesis 1:27"
           },
           {
             "content": "And God blessed them, and God said unto them, Be fruitful, and multiply, and replenish the earth, and subdue it: and have dominion over the fish of the sea, and over the fowl of the air, and over every living thing that moveth upon the earth.",
-            "reference": "GEN.1.28"
+            "reference": "Genesis 1:28"
           },
           {
             "content": "And God said, Behold, I have given you every herb bearing seed, which is upon the face of all the earth, and every tree, in the which is the fruit of a tree yielding seed; to you it shall be for meat.",
-            "reference": "GEN.1.29"
+            "reference": "Genesis 1:29"
           },
           {
             "content": "And to every beast of the earth, and to every fowl of the air, and to every thing that creepeth upon the earth, wherein there is life, I have given every green herb for meat: and it was so.",
-            "reference": "GEN.1.30"
+            "reference": "Genesis 1:30"
           },
           {
             "content": "And God saw every thing that he had made, and, behold, it was very good. And the evening and the morning were the sixth day.",
-            "reference": "GEN.1.31"
+            "reference": "Genesis 1:31"
           }
         ]
       }
 
       const chapter = await bibleScraper.chapter(reference);
 
-      expect(chapter).toEqual(expectedChapter);
+      expect(chapter.verses).toEqual(expectedChapter.verses);
+      expect(chapter.reference).toEqual(expectedChapter.reference);
+      expect(chapter.version).toEqual(expectedChapter.version);
     });
   });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -225,7 +225,10 @@ describe('BibleScraper', () => {
             "content": "And God saw every thing that he had made, and, behold, it was very good. And the evening and the morning were the sixth day.",
             "reference": "Genesis 1:31"
           }
-        ]
+        ],
+        audioBibleUrl: 'https://audio-bible-cdn.youversionapi.com',
+        copyright: "Rights in the Authorized (King James) Version in the United Kingdom are vested in the Crown. Published by permission of the Crown’s patentee, Cambridge University Press.",
+        audioBibleCopyright: "Copyright 2007 Fellowship for the Performing Arts"
       }
 
       const chapter = await bibleScraper.chapter(reference);
@@ -233,6 +236,9 @@ describe('BibleScraper', () => {
       expect(chapter.verses).toEqual(expectedChapter.verses);
       expect(chapter.reference).toEqual(expectedChapter.reference);
       expect(chapter.version).toEqual(expectedChapter.version);
+      expect(chapter.audioBibleCopyright).toEqual(expectedChapter.audioBibleCopyright);
+      expect(chapter.copyright).toEqual(expectedChapter.copyright);
+      expect(chapter.audioBibleUrl).toContain(expectedChapter.audioBibleUrl);
     });
   });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,233 @@
+const BibleScraper = require('../lib/index.js');
+
+describe('BibleScraper', () => {
+  const translationId = BibleScraper.TRANSLATIONS.KJV;
+
+  describe('url', () => {
+    it('should return the correct URL for a given reference', () => {
+      const bibleScraper = new BibleScraper(translationId);
+      const reference = 'GEN.1';
+      const expectedUrl = `https://www.bible.com/bible/${translationId}/${reference}`;
+
+      const url = bibleScraper.url(reference);
+
+      expect(url).toBe(expectedUrl);
+    });
+  });
+
+  describe('getBibleReference', () => {
+    it('should generate the correct bible reference', () => {
+      const bibleScraper = new BibleScraper(translationId);
+      const params = {
+        book: 'Genesis',
+        chapter: 1,
+        verseNumStart: 1,
+        verseNumEnd: 3,
+      };
+      const expectedReference = `GEN.1.1-3.${translationId}`;
+
+      const reference = bibleScraper.getBibleReference(params);
+
+      expect(reference).toBe(expectedReference);
+    });
+
+    it('should handle optional verseNumEnd', () => {
+      const bibleScraper = new BibleScraper(translationId);
+      const params = {
+        book: 'Genesis',
+        chapter: 1,
+        verseNumStart: 1,
+      };
+      const expectedReference = `GEN.1.1.${translationId}`;
+
+      const reference = bibleScraper.getBibleReference(params);
+
+      expect(reference).toBe(expectedReference);
+    });
+
+    it('should log a warning for invalid book name', () => {
+      const bibleScraper = new BibleScraper(translationId);
+      const params = {
+        book: 'InvalidBook',
+        chapter: 1,
+        verseNumStart: 1,
+        verseNumEnd: 3,
+      };
+
+      const consoleWarnSpy = jest.spyOn(console, 'warn');
+      bibleScraper.getBibleReference(params);
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Please provide a valid book name using the `BibleScraper.BOOKS` array.'
+      );
+    });
+
+    it('should log a warning for missing chapter number', () => {
+      const bibleScraper = new BibleScraper(translationId);
+      const params = {
+        book: 'Genesis',
+        verseNumStart: 1,
+        verseNumEnd: 3,
+      };
+
+      const consoleWarnSpy = jest.spyOn(console, 'warn');
+      bibleScraper.getBibleReference(params);
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith('Please provide a chapter number.');
+    });
+  });
+
+  describe('verse', () => {
+    it('should fetch the verse from bible.com', async () => {
+      const bibleScraper = new BibleScraper(translationId);
+      const reference = 'GEN.1.1';
+      const expectedVerse = {
+        content: 'In the beginning God created the heaven and the earth.',
+        reference: 'Genesis 1:1 KJV',
+      };
+
+      const verse = await bibleScraper.verse(reference);
+
+      expect(verse).toEqual(expectedVerse);
+    });
+  });
+
+  describe('chapter', () => {
+    it('should fetch the chapter verses from bible.com', async () => {
+      const bibleScraper = new BibleScraper(translationId);
+      const reference = 'GEN.1';
+      const expectedChapter = {
+        "verses": [
+          {
+            "content": "In the beginning God created the heaven and the earth.",
+            "reference": "GEN.1.1"
+          },
+          {
+            "content": "And the earth was without form, and void; and darkness was upon the face of the deep. And the Spirit of God moved upon the face of the waters.",
+            "reference": "GEN.1.2"
+          },
+          {
+            "content": "And God said, Let there be light: and there was light.",
+            "reference": "GEN.1.3"
+          },
+          {
+            "content": "And God saw the light, that it was good: and God divided the light from the darkness.",
+            "reference": "GEN.1.4"
+          },
+          {
+            "content": "And God called the light Day, and the darkness he called Night. And the evening and the morning were the first day.",
+            "reference": "GEN.1.5"
+          },
+          {
+            "content": "And God said, Let there be a firmament in the midst of the waters, and let it divide the waters from the waters.",
+            "reference": "GEN.1.6"
+          },
+          {
+            "content": "And God made the firmament, and divided the waters which were under the firmament from the waters which were above the firmament: and it was so.",
+            "reference": "GEN.1.7"
+          },
+          {
+            "content": "And God called the firmament Heaven. And the evening and the morning were the second day.",
+            "reference": "GEN.1.8"
+          },
+          {
+            "content": "And God said, Let the waters under the heaven be gathered together unto one place, and let the dry land appear: and it was so.",
+            "reference": "GEN.1.9"
+          },
+          {
+            "content": "And God called the dry land Earth; and the gathering together of the waters called he Seas: and God saw that it was good.",
+            "reference": "GEN.1.10"
+          },
+          {
+            "content": "And God said, Let the earth bring forth grass, the herb yielding seed, and the fruit tree yielding fruit after his kind, whose seed is in itself, upon the earth: and it was so.",
+            "reference": "GEN.1.11"
+          },
+          {
+            "content": "And the earth brought forth grass, and herb yielding seed after his kind, and the tree yielding fruit, whose seed was in itself, after his kind: and God saw that it was good.",
+            "reference": "GEN.1.12"
+          },
+          {
+            "content": "And the evening and the morning were the third day.",
+            "reference": "GEN.1.13"
+          },
+          {
+            "content": "And God said, Let there be lights in the firmament of the heaven to divide the day from the night; and let them be for signs, and for seasons, and for days, and years:",
+            "reference": "GEN.1.14"
+          },
+          {
+            "content": "and let them be for lights in the firmament of the heaven to give light upon the earth: and it was so.",
+            "reference": "GEN.1.15"
+          },
+          {
+            "content": "And God made two great lights; the greater light to rule the day, and the lesser light to rule the night: he made the stars also.",
+            "reference": "GEN.1.16"
+          },
+          {
+            "content": "And God set them in the firmament of the heaven to give light upon the earth,",
+            "reference": "GEN.1.17"
+          },
+          {
+            "content": "and to rule over the day and over the night, and to divide the light from the darkness: and God saw that it was good.",
+            "reference": "GEN.1.18"
+          },
+          {
+            "content": "And the evening and the morning were the fourth day.",
+            "reference": "GEN.1.19"
+          },
+          {
+            "content": "And God said, Let the waters bring forth abundantly the moving creature that hath life, and fowl that may fly above the earth in the open firmament of heaven.",
+            "reference": "GEN.1.20"
+          },
+          {
+            "content": "And God created great whales, and every living creature that moveth, which the waters brought forth abundantly, after their kind, and every winged fowl after his kind: and God saw that it was good.",
+            "reference": "GEN.1.21"
+          },
+          {
+            "content": "And God blessed them, saying, Be fruitful, and multiply, and fill the waters in the seas, and let fowl multiply in the earth.",
+            "reference": "GEN.1.22"
+          },
+          {
+            "content": "And the evening and the morning were the fifth day.",
+            "reference": "GEN.1.23"
+          },
+          {
+            "content": "And God said, Let the earth bring forth the living creature after his kind, cattle, and creeping thing, and beast of the earth after his kind: and it was so.",
+            "reference": "GEN.1.24"
+          },
+          {
+            "content": "And God made the beast of the earth after his kind, and cattle after their kind, and every thing that creepeth upon the earth after his kind: and God saw that it was good.",
+            "reference": "GEN.1.25"
+          },
+          {
+            "content": "And God said, Let us make man in our image, after our likeness: and let them have dominion over the fish of the sea, and over the fowl of the air, and over the cattle, and over all the earth, and over every creeping thing that creepeth upon the earth.",
+            "reference": "GEN.1.26"
+          },
+          {
+            "content": "So God created man in his own image, in the image of God created he him; male and female created he them.",
+            "reference": "GEN.1.27"
+          },
+          {
+            "content": "And God blessed them, and God said unto them, Be fruitful, and multiply, and replenish the earth, and subdue it: and have dominion over the fish of the sea, and over the fowl of the air, and over every living thing that moveth upon the earth.",
+            "reference": "GEN.1.28"
+          },
+          {
+            "content": "And God said, Behold, I have given you every herb bearing seed, which is upon the face of all the earth, and every tree, in the which is the fruit of a tree yielding seed; to you it shall be for meat.",
+            "reference": "GEN.1.29"
+          },
+          {
+            "content": "And to every beast of the earth, and to every fowl of the air, and to every thing that creepeth upon the earth, wherein there is life, I have given every green herb for meat: and it was so.",
+            "reference": "GEN.1.30"
+          },
+          {
+            "content": "And God saw every thing that he had made, and, behold, it was very good. And the evening and the morning were the sixth day.",
+            "reference": "GEN.1.31"
+          }
+        ]
+      }
+
+      const chapter = await bibleScraper.chapter(reference);
+
+      expect(chapter).toEqual(expectedChapter);
+    });
+  });
+});


### PR DESCRIPTION
Improvements by @cameronapak -- thank you! :cake:

- Added all available English Bible Versions
- Added list of Bible book names and their respective USFM shortcode
- Added function to construct the Bible.com url to scrape from 
- Made Bible Versions have intellisense when developing
- Exposed Bible Versions using `BibleScraper.TRANSLATIONS` static property
- Exposed the Bible Books using `BibleScraper.BOOKS` static property
- Added Jest testing and test file, available via `npm run test`
- For chapters, it now returns the audio Bible URL. Could be fun for anyone who wants bible Audio!

Things changed:

- Made it where fetching a Bible verse or few verses is more robust and less error prone (see comments in the code)
- Made the chapter get element selectors more robust to prevent future errors when YouVersion changes a classname and it bundles a different name
