### PR TITLE
Add handle for translations without audioBible

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -346,13 +346,26 @@ module.exports = class BibleScraper {
             const nextJSData = JSON.parse(data.nextJSDataString || '{}')
 
             bibleReferenceWithoutVersion = nextJSData.props.pageProps.chapterInfo.reference.human
-            let audioBibleUrl = nextJSData.props.pageProps.chapterInfo.audioChapterInfo[0].download_urls.format_mp3_32k
+            let audioBibleUrl
+            try {
+                audioBibleUrl = nextJSData.props.pageProps.chapterInfo.audioChapterInfo[0].download_urls.format_mp3_32k;
+            } catch (error) {
+                audioBibleUrl = null
+            }
 
             chapter.version = nextJSData.props.pageProps.versionData.local_abbreviation
             chapter.reference = bibleReferenceWithoutVersion + ' ' + chapter.version
-            chapter.audioBibleUrl = audioBibleUrl.replace('//', 'https://')
+            try {
+                chapter.audioBibleUrl = audioBibleUrl.replace('//', 'https://');
+            } catch (error) {
+                chapter.audioBibleUrl = null
+            }
             chapter.copyright = nextJSData.props.pageProps.chapterInfo.copyright.text
-            chapter.audioBibleCopyright = nextJSData.props.pageProps.audioVersionInfo.copyright_short.text
+            try {
+                chapter.audioBibleCopyright = nextJSData.props.pageProps.audioVersionInfo.copyright_short.text;
+            } catch (error) {
+                chapter.audioBibleCopyright = null
+            }
         }
 
         chapter.verses = (data.verses || []).reduce((acc, c) => {


### PR DESCRIPTION
For the Passion Translation (ID: 1849), there are no available audioBooks in YouVersion. Hence, it returns an error when trying to scrape this version. 

With this it returns a chapter scrape request will return:

 ```
 verses: [
    {
      content: 'If I were to speak with eloquence in earth’s many languages, and in the heavenly tongues of angels,  yet I didn’t express myself 
with love,  my words would be reduced to the hollow sound of nothing more than a clanging cymbal.',
      reference: '1 Corinthians 13:1'
    },
    {
      content: 'And if I were to have the gift of prophecy  with a profound understanding of God’s hidden secrets, and if I possessed unending supernatural knowledge, and if I had the greatest gift of faith that could move mountains,  but have never learned to love, then I am nothing.',   
      reference: '1 Corinthians 13:2'
    },
    ....
    {
      content: 'Until then, there are three things that remain: faith, hope, and love—yet love surpasses them all.  So above all else, let love be the beautiful prize for which you run.',
      reference: '1 Corinthians 13:13'
    }
  ],
  version: 'TPT',
  reference: '1 Corinthians 13 TPT',
  audioBibleUrl: null,
  copyright: 'The Passion Translation® is a registered trademark of Passion & Fire Ministries, Inc.\r\n' +
    'Copyright © 2020 Passion & Fire Ministries, Inc.',
  audioBibleCopyright: null
}
```